### PR TITLE
Fix Windows building with Mingw(tdm-gcc)

### DIFF
--- a/lpath.c
+++ b/lpath.c
@@ -39,6 +39,9 @@ static void *luaL_prepbuffsize(luaL_Buffer *B, size_t len) {
 #  define EXT_SEP  "."
 #  define PAR_DIR  ".."
 #  define PATH_SEP ";"
+// Redefine _In_ and _Out_ to empty values
+#  define _In_
+#  define _Out_
 #else
 #  define ALT_SEP  "/"
 #  define CUR_DIR  "."


### PR DESCRIPTION
> C:\Users\darksun>gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=D:/TDM-GCC-32/bin/../libexec/gcc/mingw32/5.1.0/lto-wrapper.exe
Target: mingw32
Configured with: ../../../src/gcc-5.1.0/configure --build=mingw32 --enable-languages=ada,c,c++,fortran,lto,objc,obj-c++ --enable-libgomp --enable-lto --enable-graphite --enable-libstdcxx-debug --enable-threads=posix --enable-version-specific-runtime-libs --enable-fully-dynamic-string --enable-libstdcxx-threads --enable-libstdcxx-time --with-gnu-ld --disable-werror --disable-nls --disable-win32-registry --disable-symvers --enable-cxx-flags='-fno-function-sections -fno-data-sections -DWINPTHREAD_STATIC' --prefix=/mingw32tdm --with-local-prefix=/mingw32tdm --with-pkgversion=tdm-1 --enable-sjlj-exceptions --with-bugurl=http://tdm-gcc.tdragon.net/bugs
Thread model: posix
gcc version 5.1.0 (tdm-1)

When I was trying to install your lpath module with luarocks(mingw based),following error occured.

> mingw32-gcc -O2 -c -o lpath.o -ID:/TDM-GCC-32/include/lua5.3 lpath.c
lpath.c:706:3: error: unknown type name '_In_'
   _In_   HANDLE hFile,
   ^
lpath.c:707:3: error: unknown type name '_Out_'
   _Out_  LPWSTR lpszFilePath,
   ^
lpath.c:708:3: error: unknown type name '_In_'
   _In_   DWORD cchFilePath,
   ^
lpath.c:709:3: error: unknown type name '_In_'
   _In_   DWORD dwFlags
   ^

It seems my mingw doesn't provide such marcos like `_In_` and `_Out_`.Since it's useless,I define it into empty and build it again,succeeded.
Maybe it will trouble others,so I push my small patch to your repo,merge if you like :).