### PR TITLE
fix env.set segfault

### DIFF
--- a/lpath.c
+++ b/lpath.c
@@ -1455,6 +1455,10 @@ static int lpL_getenv(lua_State *L) {
 static int lpL_setenv(lua_State *L) {
     const char *name = luaL_checkstring(L, 1);
     const char *value = luaL_optstring(L, 2, NULL);
+    if (value == NULL) {
+        return unsetenv(name) == 0 ? (lua_settop(L, 2), 1) :
+            -lp_pusherror(L, "unsetenv", NULL);
+    }
     return setenv(name, value, 1) == 0 ? (lua_settop(L, 2), 1) :
         -lp_pusherror(L, "setenv", NULL);
 }


### PR DESCRIPTION
setenv may not be called with NULL as second argument or LIBC will segfault.

this could be achieved by doing the following:

Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio
> lpath = require("path.env")
> print(lpath.set("fu", nil))
[1]    28569 segmentation fault  lua

I suggest calling unsetenv in this case as this will remove the environment variable. 
This is probably what a caller intends when passing 'nil' as the second argument.