### PR TITLE
Fix unit test when using luaj

### DIFF
--- a/lpath.c
+++ b/lpath.c
@@ -1455,6 +1455,10 @@ static int lpL_getenv(lua_State *L) {
 static int lpL_setenv(lua_State *L) {
     const char *name = luaL_checkstring(L, 1);
     const char *value = luaL_optstring(L, 2, NULL);
+    if (value == NULL) {
+        return unsetenv(name) == 0 ? (lua_settop(L, 2), 1) :
+            -lp_pusherror(L, "unsetenv", NULL);
+    }
     return setenv(name, value, 1) == 0 ? (lua_settop(L, 2), 1) :
         -lp_pusherror(L, "setenv", NULL);
 }

--- a/test.lua
+++ b/test.lua
@@ -690,7 +690,7 @@ function _G.test_env()
       eq(env.set("FOO", "BAR"), "BAR")
       eq(env.get "FOO", "BAR")
       eq(env.expand "abc${FOO}abc", "abcBARabc")
-      fail(".-syntax error",
+      fail(".-syntax error.*",
          function() assert(env.expand("$(ls /")) end)
    end
 end


### PR DESCRIPTION
Hello, when using luaj the debuglib needed by luaunit.lua will fill the traceback message of all lua errors.

This causes the check for syntax error to fail.
You are testing for ".-syntax error" but in luaj the error thrown by assert is:
test.lua:694 syntax error
stack traceback:
	test.lua:694: in function <test.lua:694>
	[Java]: in function 'pcall'
	luaunit.lua:1318: in function 'fail'
	test.lua:693: in function 'methodInstance'
	luaunit.lua:2442: in function 'xpcall'
	luaunit.lua:2442: in function 'protectedCall'
	luaunit.lua:2516: in function 'execOneFunction'
	luaunit.lua:2619: in function 'runSuiteByInstances'
	luaunit.lua:2691: in function 'runSuiteByNames'
	luaunit.lua:2743: in function 'run'
	test.lua:1104: in main chunk
	[Java]: in ?

If you adjust the pattern to .-syntax error.* it will no longer fail.